### PR TITLE
Fixed README headers rendering issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ pip install django-webpack-loader
 ```
 
 <br>
+
 ## Configuration
 
 <br>
+
 ### Assumptions
 
 Assuming `BASE_DIR` in settings refers to the root of your django app.


### PR DESCRIPTION
These lines weren't rendering as the headers they're notated to be. Looks worse on the PyPi page [django-webpack-loader](https://pypi.python.org/pypi/django-webpack-loader/0.4.1). My fix causes it to render correctly on GitHub hopefully that will transfer over. Thanks for the work!

**Before** | **After**
--- | ---
[Page before fix](https://github.com/ezhome/django-webpack-loader#install) | [Page after fix](https://github.com/3ygun/django-webpack-loader/blob/fa80fe51666498bbd460aedc5ae9d1d02717c542/README.md#install)
![django-webpack-loader-before](https://cloud.githubusercontent.com/assets/5482320/25309701/f7c356e6-27a1-11e7-8ffb-e1928f74f5a8.PNG) | ![django-webpack-loader-after](https://cloud.githubusercontent.com/assets/5482320/25309706/0bbebc12-27a2-11e7-9701-66e1455be49a.PNG)

# Current PyPi

![django-webpack-loader-pypi](https://cloud.githubusercontent.com/assets/5482320/25309709/13202130-27a2-11e7-9721-a5a9d8b5a840.PNG)
