### PR TITLE
Fix for No 'Access-Control-Allow-Origin' header is present error.

### DIFF
--- a/examples/hot-reload/server.js
+++ b/examples/hot-reload/server.js
@@ -6,7 +6,8 @@ new WebpackDevServer(webpack(config), {
   publicPath: config.output.publicPath,
   hot: true,
   inline: true,
-  historyApiFallback: true
+  historyApiFallback: true,
+  headers: { 'Access-Control-Allow-Origin': '*' }
 }).listen(3000, '0.0.0.0', function (err, result) {
   if (err) {
     console.log(err);


### PR DESCRIPTION
When I change something on the page I got following error from update request:

```XMLHttpRequest cannot load http://localhost:3000/assets/bundles/108f5136d63f38ea9442.hot-update.json. No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://localhost:8000' is therefore not allowed access.```

Fix was to add Access control header to hot reload server responses.