### PR TITLE
OUTDATED: Fix #101, CACHE setting doesn't work

### DIFF
--- a/webpack_loader/loader.py
+++ b/webpack_loader/loader.py
@@ -33,10 +33,13 @@ class WebpackLoader(object):
 
     def get_assets(self):
         if self.config['CACHE']:
+            # Load from file if it's the first time, otherwise cache
             if self.name not in self._assets:
                 self._assets[self.name] = self._load_assets()
             return self._assets[self.name]
-        return self._load_assets()
+        else:
+            # Always load from file
+            return self._load_assets()
 
     def filter_chunks(self, chunks):
         for chunk in chunks:


### PR DESCRIPTION
## UPDATE: This fix was unnecessary, CACHE is working, but it's cache-on read, not on server start, so it can be tricky

This fixes the issue identified by many people in #101. The CACHE setting documented in the README just doesn't work. It's due to a code scoping issue (see fix).

I didn't add any tests because I'm not sure how to run the tests. I saw where they are, I just don't know how to run them and don't see it in the README. I'm happy to add tests if you can teach me how to run them.

For what it's worth, I think running the Webpack build step in production before restarting your server is a totally legitimate and probably common use case. Many Django users also do this with `collectstatic`. For this to work, CACHE needs to work.